### PR TITLE
Create Claude skill for project documentation

### DIFF
--- a/ClaudeProjectDocs/claude-project-docs/CHANGELOG.md
+++ b/ClaudeProjectDocs/claude-project-docs/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to Claude Project Docs will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-12-07
+
+### Added
+
+- Initial release of Claude Project Docs skill
+- Core SKILL.md with CLAUDE.md generation methodology
+- The 60-Line Rule for optimal CLAUDE.md sizing
+- WHAT/WHY/HOW structure template
+- Progressive disclosure via agent_docs/ pattern
+- Comprehensive anti-patterns guide
+- Reference templates:
+  - `claude-md-template.md` - Minimal starter template
+  - `agent-docs-catalog.md` - Complete agent_docs file specifications
+  - `anti-patterns.md` - What NOT to include guide
+- Project-type examples:
+  - `examples/minimal-web-app.md` - Next.js + PostgreSQL example
+  - `examples/minimal-python.md` - Python library example
+  - `examples/minimal-monorepo.md` - TypeScript monorepo example
+- Audit capability for existing CLAUDE.md files
+- Agent docs generation workflow
+
+### Research Foundation
+
+Based on recommendations from:
+- HumanLayer: Writing a good CLAUDE.md
+- Claude Code Best Practices (Anthropic)
+- Community patterns from claude-md-examples

--- a/ClaudeProjectDocs/claude-project-docs/LICENSE
+++ b/ClaudeProjectDocs/claude-project-docs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AISkills Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ClaudeProjectDocs/claude-project-docs/README.md
+++ b/ClaudeProjectDocs/claude-project-docs/README.md
@@ -1,0 +1,179 @@
+# Claude Project Docs
+
+**Generate concise CLAUDE.md files and agent documentation following best practices**
+
+Create well-crafted, minimal CLAUDE.md files (~60 lines) with progressive disclosure through an `agent_docs/` directory structure.
+
+## Why This Skill?
+
+Most CLAUDE.md files are too long. Research indicates:
+
+- LLMs reliably follow ~150-200 instructions
+- Smaller/non-thinking models follow even fewer
+- Instructions at peripheries (beginning/end) get priority
+- Every unnecessary line degrades overall compliance
+
+**The solution:** Minimal CLAUDE.md + progressive disclosure via `agent_docs/`.
+
+## Features
+
+### 1. Generate CLAUDE.md
+
+Create a focused, ~60-line CLAUDE.md covering:
+- Project identity (what this is)
+- Tech stack (essential technologies)
+- Project structure (directory overview)
+- Development commands (build, test, run)
+- Critical rules (non-negotiable constraints)
+- Reference pointers (to agent_docs/)
+
+### 2. Audit Existing CLAUDE.md
+
+Analyze existing files for:
+- Line count (flag if > 100 lines)
+- Anti-patterns (code style, implementation examples)
+- Task-specific content (should be in agent_docs/)
+- Missing essentials (no tech stack, no commands)
+
+### 3. Create Agent Docs Structure
+
+Generate `agent_docs/` with task-specific documentation:
+
+```
+agent_docs/
+├── building.md      # Build commands, compilation
+├── testing.md       # Test commands, coverage
+├── architecture.md  # System design decisions
+├── database.md      # Schema, migrations
+└── deployment.md    # Deploy process, environments
+```
+
+## Usage
+
+### Set Up a New Project
+
+```
+"Set up Claude for this project"
+"Create a CLAUDE.md for this codebase"
+"Help Claude understand this project"
+```
+
+### Audit Existing Documentation
+
+```
+"Audit my CLAUDE.md"
+"Is my CLAUDE.md too long?"
+"Review my Claude documentation"
+```
+
+### Create Specific Agent Docs
+
+```
+"Create agent docs for testing"
+"Set up agent_docs for this project"
+"Create a building.md for agent_docs"
+```
+
+## Best Practices Enforced
+
+### The 60-Line Rule
+
+| Lines | Assessment |
+|-------|------------|
+| < 60 | Ideal |
+| 60-100 | Acceptable |
+| 100-300 | Too long, audit needed |
+| > 300 | Critical, immediate refactor |
+
+### WHAT/WHY/HOW Structure
+
+Every CLAUDE.md should answer:
+- **WHAT**: Tech stack, project structure
+- **WHY**: Project purpose, key decisions
+- **HOW**: Development workflow, essential commands
+
+### Anti-Patterns Prevented
+
+| Anti-Pattern | Why Bad | Alternative |
+|--------------|---------|-------------|
+| Code style rules | Use linters | ESLint, Prettier, Black |
+| Full command docs | Bloats context | `agent_docs/` |
+| Implementation examples | Gets stale | Point to actual code |
+| Generated via /init | Generic | Hand-crafted |
+| > 300 lines | Instruction decay | Refactor + agent_docs/ |
+
+## Example Output
+
+### Generated CLAUDE.md (~55 lines)
+
+```markdown
+# MyApp
+
+Modern e-commerce platform built with Next.js and PostgreSQL.
+
+## Tech Stack
+- Next.js 14 (App Router)
+- TypeScript
+- PostgreSQL + Prisma
+- Tailwind CSS
+- Stripe payments
+
+## Project Structure
+src/
+├── app/           # Next.js app router pages
+├── components/    # React components
+├── lib/           # Utilities and helpers
+├── server/        # API routes and server logic
+└── prisma/        # Database schema and migrations
+
+## Development
+
+Build: `npm run build`
+Test: `npm test`
+Dev: `npm run dev`
+Lint: `npm run lint` (auto-fixes on save)
+
+## Critical Rules
+- All payments through Stripe API only
+- Never commit .env files
+- Run `npm test` before pushing
+
+## Reference Documentation
+When working on specific tasks, read:
+- `agent_docs/testing.md` - Test patterns and fixtures
+- `agent_docs/database.md` - Prisma schema and migrations
+- `agent_docs/deployment.md` - Vercel deployment process
+```
+
+## Research Foundation
+
+Based on recommendations from:
+- [HumanLayer: Writing a good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md)
+- [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)
+- Community patterns from claude-md-examples
+
+Key insight: "You're writing for Claude, not onboarding a junior dev." Use short, declarative bullet points.
+
+## Installation
+
+### Claude Code
+
+```bash
+# Global installation
+cp -r claude-project-docs ~/.claude/skills/
+
+# Project-specific
+cp -r claude-project-docs .claude/skills/
+```
+
+### Claude Web Chat
+
+Upload the `.skill` file from `dist/` via Settings > Capabilities > Skills.
+
+## Version
+
+v1.0.0 - Initial release
+
+## License
+
+MIT License

--- a/ClaudeProjectDocs/claude-project-docs/SKILL.md
+++ b/ClaudeProjectDocs/claude-project-docs/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: claude-project-docs
+description: Generate concise CLAUDE.md files and agent documentation following best practices. Use when setting up a new project for Claude Code, auditing existing CLAUDE.md, or creating progressive disclosure documentation structure.
+---
+
+# Claude Project Docs
+
+Create well-crafted, minimal CLAUDE.md files (~60 lines) with progressive disclosure through agent_docs/.
+
+## When to Use
+
+Invoke when user:
+- Asks to "set up Claude for this project" or "create a CLAUDE.md"
+- Wants to "audit" or "improve" their existing CLAUDE.md
+- Needs to create agent documentation or progressive disclosure structure
+- Says "help Claude understand this codebase"
+
+## Core Methodology
+
+### The 60-Line Rule
+
+CLAUDE.md goes into EVERY session. Keep it:
+- **< 60 lines** ideal (HumanLayer recommendation)
+- **< 300 lines** absolute maximum
+- **Universally applicable** - no task-specific content
+
+### WHAT/WHY/HOW Structure
+
+```markdown
+# Project Name
+
+[One sentence: what this is]
+
+## Tech Stack
+- [Framework/Language]
+- [Key dependencies]
+
+## Project Structure
+[3-5 line overview of directories that matter]
+
+## Development
+[Essential commands only - build, test, run]
+
+## Critical Rules
+[2-3 non-negotiable constraints]
+
+## Reference Documentation
+When working on specific tasks, read:
+- `agent_docs/[topic].md`
+```
+
+### Progressive Disclosure
+
+Create `agent_docs/` for task-specific documentation:
+
+| File | Content |
+|------|---------|
+| `building.md` | Build commands, compilation, bundling |
+| `testing.md` | Test commands, coverage, fixtures |
+| `architecture.md` | System design, key decisions |
+| `database.md` | Schema, migrations, connections |
+| `deployment.md` | Deploy process, environments |
+
+Claude reads these ON DEMAND, not every session.
+
+## Anti-Patterns to Prevent
+
+**NEVER include in CLAUDE.md:**
+- Code style rules (use ESLint/Prettier/linters)
+- Full command documentation (use agent_docs/)
+- Implementation examples (point to actual code)
+- > 300 lines of content
+- Generic boilerplate from /init
+
+**Why:** LLMs follow ~150-200 instructions reliably. Every unnecessary line degrades compliance.
+
+## Workflow
+
+### 1. Generate New CLAUDE.md
+
+```
+User: Set up Claude for this project
+→ Analyze: package.json, pyproject.toml, go.mod, Makefile
+→ Generate: Minimal CLAUDE.md (~60 lines)
+→ Create: agent_docs/ structure
+```
+
+### 2. Audit Existing CLAUDE.md
+
+```
+User: Audit my CLAUDE.md
+→ Check: Line count, anti-patterns, task-specific content
+→ Report: Issues found with severity
+→ Suggest: Specific removals and agent_docs/ migrations
+```
+
+### 3. Create Agent Docs
+
+```
+User: Create agent docs for testing
+→ Generate: agent_docs/testing.md with project-specific content
+→ Update: CLAUDE.md reference section
+```
+
+## Output Format
+
+When generating CLAUDE.md:
+1. Show the complete file content
+2. Explain what was included and why
+3. List what was intentionally excluded
+4. Suggest agent_docs/ files to create next
+
+## References
+
+For templates and examples:
+- `references/claude-md-template.md` - Minimal starter template
+- `references/agent-docs-catalog.md` - Complete agent_docs file list
+- `references/anti-patterns.md` - Detailed anti-pattern guide
+- `references/examples/` - Project-type examples
+
+---
+
+**Principle:** High leverage documentation. Every line in CLAUDE.md costs context across all sessions.

--- a/ClaudeProjectDocs/claude-project-docs/references/agent-docs-catalog.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/agent-docs-catalog.md
@@ -1,0 +1,293 @@
+# Agent Docs Catalog
+
+Complete catalog of `agent_docs/` files for progressive disclosure.
+
+## Core Principle
+
+CLAUDE.md is read every session. `agent_docs/` files are read on-demand.
+
+Put task-specific content in agent_docs/ to:
+- Reduce CLAUDE.md bloat
+- Keep session context focused
+- Allow detailed documentation per topic
+
+## Directory Structure
+
+```
+project-root/
+├── CLAUDE.md              # ~60 lines, universal
+└── agent_docs/
+    ├── building.md        # Build and compilation
+    ├── testing.md         # Test patterns and execution
+    ├── architecture.md    # System design
+    ├── database.md        # Data layer
+    ├── deployment.md      # Deploy process
+    ├── api.md             # API design patterns
+    ├── security.md        # Security practices
+    └── debugging.md       # Debug workflows
+```
+
+## File Specifications
+
+### building.md
+
+**Purpose:** Build process, compilation, bundling
+
+**Include:**
+- Build commands with common flags
+- Environment-specific builds (dev, staging, prod)
+- Build artifacts and their locations
+- Common build errors and fixes
+- Asset pipeline details
+
+**Template:**
+```markdown
+# Building
+
+## Quick Commands
+- Dev build: `npm run build:dev`
+- Prod build: `npm run build:prod`
+- Watch mode: `npm run build:watch`
+
+## Build Artifacts
+Output goes to `dist/`:
+- `dist/server/` - Node.js server bundle
+- `dist/client/` - Browser assets
+
+## Environment Variables
+Build respects these env vars:
+- `NODE_ENV` - development|production
+- `API_URL` - Backend API endpoint
+
+## Common Issues
+[List 2-3 frequent build problems and solutions]
+```
+
+---
+
+### testing.md
+
+**Purpose:** Test execution, patterns, fixtures
+
+**Include:**
+- Test commands (unit, integration, e2e)
+- Test file locations and naming
+- Fixture/mock patterns used
+- Coverage requirements
+- CI test configuration
+
+**Template:**
+```markdown
+# Testing
+
+## Quick Commands
+- All tests: `npm test`
+- Unit only: `npm run test:unit`
+- E2E: `npm run test:e2e`
+- Coverage: `npm run test:coverage`
+
+## Test Structure
+tests/
+├── unit/          # Fast, isolated tests
+├── integration/   # Service integration tests
+└── e2e/           # Full workflow tests
+
+## Fixtures
+Fixtures in `tests/fixtures/`. Load with:
+```typescript
+import { loadFixture } from '@/tests/helpers'
+const user = loadFixture('user-active')
+```
+
+## Coverage Requirements
+- Minimum: 80% line coverage
+- New code: Must include tests
+- CI fails below threshold
+```
+
+---
+
+### architecture.md
+
+**Purpose:** System design, key decisions, patterns
+
+**Include:**
+- High-level architecture diagram (ASCII or reference)
+- Key design decisions and rationale
+- Pattern catalog used in codebase
+- Module boundaries and dependencies
+- Data flow overview
+
+**Template:**
+```markdown
+# Architecture
+
+## Overview
+[2-3 sentences describing the system]
+
+## Key Decisions
+1. **[Decision]**: [Rationale]
+2. **[Decision]**: [Rationale]
+
+## Patterns Used
+- **Repository Pattern**: Data access in `src/repositories/`
+- **Service Layer**: Business logic in `src/services/`
+- **DTOs**: API contracts in `src/dtos/`
+
+## Module Dependencies
+```
+Controllers → Services → Repositories → Database
+     ↓
+   DTOs
+```
+
+## Boundaries
+- `src/core/` - No external dependencies
+- `src/infra/` - All external integrations
+```
+
+---
+
+### database.md
+
+**Purpose:** Data layer, schema, migrations
+
+**Include:**
+- Database technology and connection
+- Schema overview (key tables/collections)
+- Migration commands and workflow
+- Seeding and fixtures
+- Query patterns and ORM usage
+
+**Template:**
+```markdown
+# Database
+
+## Technology
+PostgreSQL 15 via Prisma ORM
+
+## Connection
+- Dev: `DATABASE_URL` in `.env`
+- Prod: Managed via infrastructure
+
+## Schema Overview
+Key tables:
+- `users` - User accounts
+- `orders` - Order records
+- `products` - Product catalog
+
+Full schema: `prisma/schema.prisma`
+
+## Migrations
+- Generate: `npx prisma migrate dev --name [name]`
+- Apply: `npx prisma migrate deploy`
+- Reset: `npx prisma migrate reset`
+
+## Seeding
+`npm run db:seed` - Loads fixtures from `prisma/seed.ts`
+```
+
+---
+
+### deployment.md
+
+**Purpose:** Deploy process, environments, infrastructure
+
+**Include:**
+- Deployment commands/process
+- Environment list and URLs
+- Infrastructure overview
+- Rollback procedures
+- Secrets management
+
+**Template:**
+```markdown
+# Deployment
+
+## Environments
+| Env | URL | Branch |
+|-----|-----|--------|
+| Dev | dev.example.com | develop |
+| Staging | staging.example.com | main |
+| Prod | example.com | release/* |
+
+## Deploy Commands
+- Staging: `npm run deploy:staging`
+- Prod: `npm run deploy:prod` (requires approval)
+
+## Process
+1. PR merged to main
+2. CI runs tests
+3. Auto-deploy to staging
+4. Manual promotion to prod
+
+## Rollback
+`npm run rollback:prod -- --version=[tag]`
+
+## Secrets
+Managed in AWS Secrets Manager. Never commit `.env.prod`.
+```
+
+---
+
+### api.md
+
+**Purpose:** API design patterns, conventions
+
+**Include:**
+- API style (REST, GraphQL, etc.)
+- Endpoint naming conventions
+- Request/response patterns
+- Authentication approach
+- Error handling format
+
+---
+
+### security.md
+
+**Purpose:** Security practices, auth, sensitive data
+
+**Include:**
+- Authentication mechanism
+- Authorization patterns
+- Sensitive data handling
+- Security review process
+- Known security boundaries
+
+---
+
+### debugging.md
+
+**Purpose:** Debug workflows, logging, troubleshooting
+
+**Include:**
+- Logging configuration
+- Debug commands and tools
+- Common issues and solutions
+- Performance profiling
+- Error tracking integration
+
+## When to Create Agent Docs
+
+Create a new `agent_docs/` file when:
+
+1. **Content is task-specific** - Only relevant for certain work
+2. **Content exceeds 20 lines** - Too much for CLAUDE.md
+3. **Content changes frequently** - Isolate changes
+4. **Multiple related topics** - Group for discoverability
+
+## Referencing from CLAUDE.md
+
+Add a Reference Documentation section:
+
+```markdown
+## Reference Documentation
+When working on specific tasks, read relevant files:
+- `agent_docs/building.md` - Build process and compilation
+- `agent_docs/testing.md` - Test patterns and fixtures
+- `agent_docs/architecture.md` - System design decisions
+- `agent_docs/database.md` - Prisma schema and migrations
+- `agent_docs/deployment.md` - Deploy to staging/production
+```
+
+Claude will read these files when the task context matches.

--- a/ClaudeProjectDocs/claude-project-docs/references/anti-patterns.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/anti-patterns.md
@@ -1,0 +1,295 @@
+# Anti-Patterns Guide
+
+What NOT to include in CLAUDE.md and why.
+
+## The Core Problem
+
+CLAUDE.md content goes into every session. LLMs have limited instruction-following capacity:
+
+- **~150-200 instructions** for frontier thinking models
+- **Fewer** for smaller or non-thinking models
+- **Peripheral bias** - Beginning/end of prompt get priority
+
+Every unnecessary line in CLAUDE.md:
+1. Consumes instruction budget
+2. Dilutes important instructions
+3. Increases chance of being ignored
+
+## Anti-Pattern Catalog
+
+### 1. Code Style Rules
+
+**Bad:**
+```markdown
+## Code Style
+- Use 2-space indentation
+- Use single quotes for strings
+- Add trailing commas in arrays
+- Use arrow functions over function declarations
+- Prefer const over let
+- No semicolons
+```
+
+**Why it's bad:**
+- Linters do this faster and cheaper
+- Adds 6+ instructions Claude may ignore
+- Gets stale when config changes
+
+**What to do instead:**
+```markdown
+## Development
+Lint: `npm run lint` (auto-fixes on save)
+```
+
+Configure ESLint, Prettier, Black, etc. properly. Claude will follow existing code patterns through in-context learning.
+
+---
+
+### 2. Comprehensive Command Documentation
+
+**Bad:**
+```markdown
+## Commands
+
+### Development
+- `npm run dev` - Start development server with hot reload on port 3000
+- `npm run dev:debug` - Start with Node inspector on port 9229
+- `npm run dev:mock` - Start with mock API responses
+
+### Building
+- `npm run build` - Production build to dist/
+- `npm run build:dev` - Development build with source maps
+- `npm run build:analyze` - Build with bundle analyzer
+- `npm run build:docker` - Build Docker image
+
+### Testing
+- `npm test` - Run all tests
+- `npm run test:unit` - Unit tests only
+- `npm run test:e2e` - End-to-end tests
+- `npm run test:watch` - Watch mode
+- `npm run test:coverage` - With coverage report
+
+[...20 more commands...]
+```
+
+**Why it's bad:**
+- Bloats CLAUDE.md by 30+ lines
+- Most commands won't be used in a session
+- Package.json already documents this
+
+**What to do instead:**
+
+In CLAUDE.md (~4 lines):
+```markdown
+## Development
+Build: `npm run build`
+Test: `npm test`
+Dev: `npm run dev`
+```
+
+In `agent_docs/building.md` (full documentation):
+```markdown
+[Complete command reference here]
+```
+
+---
+
+### 3. Implementation Examples
+
+**Bad:**
+```markdown
+## API Pattern
+When creating new endpoints, follow this pattern:
+
+```typescript
+// src/routes/example.ts
+import { Router } from 'express'
+import { validateRequest } from '@/middleware/validation'
+import { exampleSchema } from '@/schemas/example'
+import { ExampleService } from '@/services/example'
+
+const router = Router()
+
+router.post('/',
+  validateRequest(exampleSchema),
+  async (req, res) => {
+    const service = new ExampleService()
+    const result = await service.create(req.body)
+    res.status(201).json(result)
+  }
+)
+
+export default router
+```
+```
+
+**Why it's bad:**
+- 20+ lines of code in system prompt
+- Gets stale when patterns change
+- Existing code shows the pattern better
+
+**What to do instead:**
+```markdown
+## Critical Rules
+- Follow existing patterns in src/routes/
+```
+
+Claude learns from your actual code through in-context learning.
+
+---
+
+### 4. Generated /init Content
+
+**Bad:**
+Using the raw output from `claude /init`:
+```markdown
+# Project
+
+This is a TypeScript project using Node.js.
+
+## Files
+- package.json: Contains dependencies
+- tsconfig.json: TypeScript configuration
+- src/: Source files
+- tests/: Test files
+
+## Scripts
+See package.json for available scripts.
+```
+
+**Why it's bad:**
+- Generic, not project-specific
+- States obvious facts
+- Provides no real guidance
+
+**What to do instead:**
+Hand-craft your CLAUDE.md. Every line should be:
+- **Non-obvious** - Claude wouldn't know without it
+- **Actionable** - Affects how Claude works
+- **Universal** - Relevant to every session
+
+---
+
+### 5. Excessive Critical Rules
+
+**Bad:**
+```markdown
+## Rules
+1. Use TypeScript for all new files
+2. Follow ESLint configuration
+3. Write tests for new functionality
+4. Use meaningful variable names
+5. Add JSDoc comments to public functions
+6. Keep functions under 50 lines
+7. Use async/await over promises
+8. Handle all errors appropriately
+9. Log important operations
+10. Validate all user input
+11. Never commit secrets
+12. Follow REST conventions
+13. Use proper HTTP status codes
+14. Document API changes in OpenAPI
+15. Update changelog for features
+```
+
+**Why it's bad:**
+- 15 rules compete for attention
+- Many are obvious or covered by linters
+- Violates the ~150 instruction limit principle
+
+**What to do instead:**
+```markdown
+## Critical Rules
+- Never modify files in `legacy/` - deprecated code
+- All API changes require OpenAPI spec update first
+- Run `npm test` before pushing
+```
+
+2-3 rules that are:
+- Non-obvious
+- Specific to this project
+- Have real consequences if violated
+
+---
+
+### 6. Team/Process Information
+
+**Bad:**
+```markdown
+## Team
+- Frontend: @alice, @bob
+- Backend: @charlie, @diana
+- DevOps: @eve
+
+## Process
+1. Create feature branch from develop
+2. Open draft PR when starting
+3. Request review from 2 team members
+4. Squash merge when approved
+5. Delete branch after merge
+
+## Meetings
+- Standup: Daily 9am
+- Sprint planning: Monday 10am
+- Retro: Friday 3pm
+```
+
+**Why it's bad:**
+- Irrelevant to Claude's work
+- Takes up instruction budget
+- Human process, not AI context
+
+**What to do instead:**
+Don't include this in CLAUDE.md. It's for humans, not agents.
+
+---
+
+### 7. Project History/Roadmap
+
+**Bad:**
+```markdown
+## History
+This project started in 2019 as a hackathon prototype...
+
+## Roadmap
+- Q1: Mobile app launch
+- Q2: International expansion
+- Q3: Enterprise features
+```
+
+**Why it's bad:**
+- Narrative text wastes tokens
+- Future plans don't help current coding
+- Gets stale
+
+**What to do instead:**
+Focus on present-state, actionable information only.
+
+---
+
+## Quick Audit Checklist
+
+Run this audit on your CLAUDE.md:
+
+| Check | Action |
+|-------|--------|
+| Line count > 100? | Trim or move to agent_docs/ |
+| Code style rules? | Delete, use linters |
+| Command list > 5? | Move to agent_docs/building.md |
+| Code examples? | Delete, point to actual code |
+| Generated by /init? | Rewrite from scratch |
+| > 5 rules? | Reduce to 2-3 critical ones |
+| Team/process info? | Delete |
+| History/roadmap? | Delete |
+| Tutorial-style prose? | Convert to bullets |
+
+## The Litmus Test
+
+For every line in CLAUDE.md, ask:
+
+1. **Is this universal?** - Applies to every session, not just some tasks
+2. **Is this non-obvious?** - Claude wouldn't know without it
+3. **Is this actionable?** - Changes how Claude works
+4. **Is this current?** - Won't become stale
+
+If any answer is "no," remove it or move it to `agent_docs/`.

--- a/ClaudeProjectDocs/claude-project-docs/references/claude-md-template.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/claude-md-template.md
@@ -1,0 +1,156 @@
+# CLAUDE.md Template
+
+Minimal template following the 60-line rule. Copy and customize.
+
+## The Template (~55 lines)
+
+```markdown
+# [Project Name]
+
+[One sentence describing what this project is and does.]
+
+## Tech Stack
+
+- [Primary language/framework]
+- [Database if applicable]
+- [Key dependencies (3-5 max)]
+
+## Project Structure
+
+```
+[root]/
+├── [main-source]/    # [Brief description]
+├── [secondary]/      # [Brief description]
+├── [config]/         # [Brief description]
+└── [tests]/          # [Brief description]
+```
+
+## Development
+
+**Build:** `[build command]`
+**Test:** `[test command]`
+**Run:** `[run/dev command]`
+**Lint:** `[lint command]` (configured in [config file])
+
+## Critical Rules
+
+- [Rule 1: Non-negotiable constraint]
+- [Rule 2: Security or architectural boundary]
+- [Rule 3: Process requirement]
+
+## Reference Documentation
+
+When working on specific tasks, read relevant files:
+- `agent_docs/building.md` - Build process and compilation
+- `agent_docs/testing.md` - Test patterns and fixtures
+- `agent_docs/architecture.md` - System design decisions
+```
+
+## Filling the Template
+
+### Project Name Section
+
+One sentence only. Answer: "What is this?"
+
+**Good:**
+```markdown
+# Acme API
+
+REST API for Acme's customer management system.
+```
+
+**Bad:**
+```markdown
+# Acme API
+
+This is the main API server for Acme Corporation's customer
+management platform. It was started in 2019 and has grown to
+support over 50 endpoints across 12 domains...
+```
+
+### Tech Stack Section
+
+3-5 items maximum. Only what Claude needs to know for code style.
+
+**Good:**
+```markdown
+## Tech Stack
+- Python 3.11 + FastAPI
+- PostgreSQL + SQLAlchemy
+- Redis for caching
+- pytest for testing
+```
+
+**Bad:**
+```markdown
+## Tech Stack
+- Python 3.11.4
+- FastAPI 0.104.1
+- PostgreSQL 15.2
+- SQLAlchemy 2.0.23
+- Redis 7.2.3
+- pytest 7.4.3
+- black 23.11.0
+- mypy 1.7.1
+- ruff 0.1.6
+- pre-commit 3.6.0
+- Docker 24.0.7
+- docker-compose 2.23.0
+...
+```
+
+### Project Structure Section
+
+Only directories that matter for navigation. 3-5 lines.
+
+### Development Section
+
+Only the commands Claude will actually run. No explanations.
+
+### Critical Rules Section
+
+2-3 rules maximum. These must be:
+- **Universal** - Apply to every task
+- **Non-obvious** - Claude wouldn't guess them
+- **Consequential** - Breaking them causes real problems
+
+**Good rules:**
+- Never modify files in `legacy/` - deprecated, will be removed
+- All API changes require OpenAPI spec update first
+- Database migrations must be reversible
+
+**Bad rules:**
+- Use 4-space indentation (that's a linter's job)
+- Write tests for new code (Claude does this anyway)
+- Follow REST conventions (too vague)
+
+### Reference Documentation Section
+
+List your `agent_docs/` files. Claude will read them when relevant.
+
+## Line Count Check
+
+Count your lines:
+```bash
+wc -l CLAUDE.md
+```
+
+| Lines | Status |
+|-------|--------|
+| < 40 | Minimal, may need more context |
+| 40-60 | Ideal range |
+| 60-100 | Acceptable, consider trimming |
+| > 100 | Too long, audit needed |
+| > 300 | Critical, refactor immediately |
+
+## What NOT to Include
+
+See `anti-patterns.md` for detailed guidance on what to exclude.
+
+Quick list:
+- Code style rules (use linters)
+- Full command documentation (use agent_docs/)
+- API documentation (use OpenAPI/docs/)
+- Onboarding instructions for humans
+- Project history or roadmap
+- Team information

--- a/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-monorepo.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-monorepo.md
@@ -1,0 +1,289 @@
+# Example: Monorepo CLAUDE.md
+
+A complete example for a TypeScript monorepo with multiple packages.
+
+## The CLAUDE.md (58 lines)
+
+```markdown
+# Acme Platform
+
+Monorepo for Acme's web platform, API, and shared packages.
+
+## Tech Stack
+
+- TypeScript (strict mode)
+- pnpm workspaces
+- Turborepo for builds
+- Packages: React (web), Fastify (api), shared libs
+
+## Project Structure
+
+```
+packages/
+├── web/           # Next.js frontend
+├── api/           # Fastify backend
+├── ui/            # Shared React components
+├── config/        # Shared configs (tsconfig, eslint)
+└── types/         # Shared TypeScript types
+apps/
+└── docs/          # Documentation site
+```
+
+## Development
+
+```bash
+# Install all packages
+pnpm install
+
+# Commands (from root)
+pnpm dev           # Start all in dev mode
+pnpm build         # Build all packages
+pnpm test          # Test all packages
+pnpm lint          # Lint all packages
+
+# Single package
+pnpm --filter web dev
+pnpm --filter api test
+```
+
+## Critical Rules
+
+- Changes to `packages/types/` require running `pnpm build` first
+- Never import from `../` across package boundaries - use package names
+- All packages must pass CI before merge
+
+## Reference Documentation
+
+When working on specific tasks, read:
+- `agent_docs/package-deps.md` - Package dependency graph
+- `agent_docs/web.md` - Frontend patterns
+- `agent_docs/api.md` - Backend patterns
+- `agent_docs/adding-packages.md` - Creating new packages
+```
+
+## Companion agent_docs/
+
+### agent_docs/package-deps.md
+
+```markdown
+# Package Dependencies
+
+## Dependency Graph
+
+```
+apps/docs ──────────────────────────────┐
+                                        ▼
+packages/web ─────┬────────────────► packages/ui
+                  │                      │
+                  ▼                      ▼
+packages/api ─────┴──────────────► packages/types
+                                        ▲
+packages/config ────────────────────────┘
+```
+
+## Package Purposes
+
+| Package | Purpose | Depends On |
+|---------|---------|------------|
+| web | Next.js frontend | ui, types, config |
+| api | Fastify backend | types, config |
+| ui | React component library | types, config |
+| types | Shared TypeScript types | config |
+| config | Shared configs | (none) |
+| docs | Documentation site | ui, types |
+
+## Import Rules
+
+Always use package names, never relative paths:
+
+```typescript
+// Correct
+import { Button } from "@acme/ui"
+import { User } from "@acme/types"
+
+// Wrong - never do this
+import { Button } from "../../ui/src/Button"
+```
+
+## Build Order
+
+Turborepo handles this automatically, but for reference:
+1. config (no deps)
+2. types (depends on config)
+3. ui (depends on types, config)
+4. api, web, docs (depend on above)
+```
+
+### agent_docs/web.md
+
+```markdown
+# Frontend (packages/web)
+
+## Tech
+- Next.js 14 with App Router
+- React Query for data fetching
+- Tailwind CSS for styling
+- Uses @acme/ui components
+
+## Structure
+src/
+├── app/           # Next.js app router
+├── features/      # Feature modules
+├── hooks/         # Custom hooks
+└── lib/           # Utilities
+
+## Patterns
+
+### Data Fetching
+Use React Query, not useEffect:
+
+```typescript
+const { data, isLoading } = useQuery({
+  queryKey: ['users'],
+  queryFn: () => api.users.list(),
+})
+```
+
+### API Client
+API client in `src/lib/api.ts`. Type-safe via @acme/types.
+
+### Components
+Prefer @acme/ui components. Only create local components
+for page-specific UI.
+
+## Running
+```bash
+pnpm --filter web dev    # Start on port 3000
+pnpm --filter web build  # Production build
+pnpm --filter web test   # Run tests
+```
+```
+
+### agent_docs/api.md
+
+```markdown
+# Backend (packages/api)
+
+## Tech
+- Fastify
+- Prisma ORM
+- PostgreSQL
+- Uses @acme/types for shared types
+
+## Structure
+src/
+├── routes/        # API route handlers
+├── services/      # Business logic
+├── repositories/  # Data access
+├── plugins/       # Fastify plugins
+└── prisma/        # Schema and migrations
+
+## Patterns
+
+### Route Structure
+```typescript
+// src/routes/users/index.ts
+export default async function(fastify: FastifyInstance) {
+  fastify.get('/', listUsers)
+  fastify.get('/:id', getUser)
+  fastify.post('/', createUser)
+}
+```
+
+### Services
+Business logic in services, not routes:
+
+```typescript
+// Route calls service
+const user = await userService.create(data)
+
+// Service handles logic
+class UserService {
+  async create(data: CreateUserInput): Promise<User> {
+    // validation, business rules, etc.
+  }
+}
+```
+
+## Running
+```bash
+pnpm --filter api dev    # Start on port 4000
+pnpm --filter api test   # Run tests
+```
+```
+
+### agent_docs/adding-packages.md
+
+```markdown
+# Adding New Packages
+
+## Steps
+
+1. Create package directory:
+```bash
+mkdir packages/new-package
+cd packages/new-package
+```
+
+2. Initialize package.json:
+```json
+{
+  "name": "@acme/new-package",
+  "version": "0.0.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch"
+  }
+}
+```
+
+3. Add tsconfig.json extending shared config:
+```json
+{
+  "extends": "@acme/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}
+```
+
+4. Install from root:
+```bash
+pnpm install
+```
+
+5. Add to dependent packages:
+```bash
+pnpm --filter web add @acme/new-package
+```
+
+## Checklist
+- [ ] Package name starts with @acme/
+- [ ] Extends shared tsconfig
+- [ ] Has build and dev scripts
+- [ ] Added to turbo.json if needed
+- [ ] Documented in agent_docs/package-deps.md
+```
+
+## Why This Works
+
+| Aspect | Implementation |
+|--------|----------------|
+| Line count | 58 lines in CLAUDE.md |
+| Workspace commands | pnpm filter syntax shown |
+| Boundary rules | Cross-package import rule is critical |
+| Progressive | Each package gets its own agent_docs/ file |
+| Build order | Turborepo handles, but explained in agent_docs/ |
+
+## Adaptation Guide
+
+To adapt for your monorepo:
+
+1. Update project name and package list
+2. Match your workspace tool (pnpm/npm/yarn)
+3. Document your package structure
+4. Add critical rules about package boundaries
+5. Create agent_docs/ per package for detailed patterns

--- a/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-python.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-python.md
@@ -1,0 +1,214 @@
+# Example: Python Library CLAUDE.md
+
+A complete example for a Python library/package.
+
+## The CLAUDE.md (48 lines)
+
+```markdown
+# DataForge
+
+Data transformation library with pandas-like API and lazy evaluation.
+
+## Tech Stack
+
+- Python 3.11+
+- No runtime dependencies (stdlib only)
+- pytest for testing
+- mypy for type checking
+
+## Project Structure
+
+```
+src/dataforge/
+├── core/          # Core transformation engine
+├── io/            # Data readers and writers
+├── ops/           # Transformation operations
+└── types/         # Type definitions
+tests/             # Test suite (mirrors src/)
+docs/              # Sphinx documentation
+```
+
+## Development
+
+```bash
+# Setup
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Commands
+pytest                    # Run tests
+mypy src/                 # Type check
+ruff check src/           # Lint
+python -m build           # Build package
+```
+
+## Critical Rules
+
+- Zero runtime dependencies - stdlib only
+- All public functions must have type hints
+- Lazy evaluation by default - never materialize early
+
+## Reference Documentation
+
+When working on specific tasks, read:
+- `agent_docs/architecture.md` - Lazy evaluation design
+- `agent_docs/testing.md` - Property-based testing patterns
+- `agent_docs/api-design.md` - Public API conventions
+```
+
+## Companion agent_docs/
+
+### agent_docs/architecture.md
+
+```markdown
+# Architecture
+
+## Core Principle: Lazy Evaluation
+
+DataForge uses lazy evaluation. Operations build a computation graph,
+only executed when `.collect()` is called.
+
+```python
+# This builds a graph, doesn't execute
+result = df.filter(col("x") > 0).select("x", "y").sort("x")
+
+# This executes the graph
+data = result.collect()
+```
+
+## Module Responsibilities
+
+### core/
+- `engine.py` - Execution engine, graph optimization
+- `frame.py` - DataFrame abstraction
+- `expr.py` - Expression DSL
+
+### ops/
+- `filter.py` - Filter operations
+- `select.py` - Column selection
+- `aggregate.py` - Groupby and aggregations
+
+### io/
+- `csv.py` - CSV reader/writer
+- `parquet.py` - Parquet support (optional dependency)
+
+## Graph Optimization
+
+Before execution, the engine optimizes:
+1. Predicate pushdown
+2. Projection pushdown
+3. Operation fusion
+
+See `core/optimizer.py` for implementation.
+```
+
+### agent_docs/testing.md
+
+```markdown
+# Testing
+
+## Commands
+- All tests: `pytest`
+- With coverage: `pytest --cov=src/dataforge`
+- Single file: `pytest tests/test_filter.py`
+- Verbose: `pytest -v`
+
+## Structure
+Tests mirror source:
+- `src/dataforge/ops/filter.py` → `tests/ops/test_filter.py`
+
+## Property-Based Testing
+
+We use Hypothesis for property-based tests:
+
+```python
+from hypothesis import given, strategies as st
+
+@given(st.lists(st.integers()))
+def test_filter_preserves_order(data):
+    df = DataFrame({"x": data})
+    result = df.filter(col("x") > 0).collect()
+    assert is_sorted_like(result, [x for x in data if x > 0])
+```
+
+## Fixtures
+Common fixtures in `tests/conftest.py`:
+- `sample_df` - Small DataFrame for unit tests
+- `large_df` - Large DataFrame for performance tests
+
+## Coverage
+Target: 90%+ coverage on core/ and ops/.
+```
+
+### agent_docs/api-design.md
+
+```markdown
+# API Design
+
+## Naming Conventions
+
+- Classes: PascalCase (`DataFrame`, `Expression`)
+- Functions: snake_case (`read_csv`, `filter_by`)
+- Constants: UPPER_SNAKE (`DEFAULT_CHUNK_SIZE`)
+
+## Method Chaining
+
+All transformation methods return self for chaining:
+
+```python
+def filter(self, predicate: Expression) -> "DataFrame":
+    # ... implementation
+    return self  # Enable chaining
+```
+
+## Error Messages
+
+Include actionable information:
+
+```python
+# Bad
+raise ValueError("Invalid column")
+
+# Good
+raise ValueError(
+    f"Column '{name}' not found. "
+    f"Available columns: {', '.join(self.columns)}"
+)
+```
+
+## Type Hints
+
+All public API must have complete type hints:
+
+```python
+def read_csv(
+    path: str | Path,
+    *,
+    delimiter: str = ",",
+    header: bool = True,
+) -> DataFrame:
+```
+
+Use `typing.overload` for polymorphic returns.
+```
+
+## Why This Works
+
+| Aspect | Implementation |
+|--------|----------------|
+| Line count | 48 lines in CLAUDE.md |
+| No dependencies | Matches project constraint |
+| Type checking | mypy command included |
+| Critical rules | Zero-dep and lazy eval are non-obvious |
+| Progressive | Architecture and API patterns in agent_docs/ |
+
+## Adaptation Guide
+
+To adapt for your Python project:
+
+1. Update project name and description
+2. List actual dependencies (or lack thereof)
+3. Update directory structure
+4. Add your virtualenv setup if different
+5. Write 2-3 critical rules (architectural constraints)
+6. Create agent_docs/ for complex subsystems

--- a/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-web-app.md
+++ b/ClaudeProjectDocs/claude-project-docs/references/examples/minimal-web-app.md
@@ -1,0 +1,176 @@
+# Example: Web Application CLAUDE.md
+
+A complete example for a Next.js + PostgreSQL web application.
+
+## The CLAUDE.md (52 lines)
+
+```markdown
+# ShopStream
+
+Modern e-commerce platform for indie brands.
+
+## Tech Stack
+
+- Next.js 14 (App Router)
+- TypeScript
+- PostgreSQL + Prisma
+- Tailwind CSS + shadcn/ui
+- Stripe for payments
+
+## Project Structure
+
+```
+src/
+├── app/           # Next.js pages and API routes
+├── components/    # React components (ui/ for shadcn)
+├── lib/           # Utilities, hooks, helpers
+├── server/        # Server-only code (actions, db)
+└── prisma/        # Database schema
+```
+
+## Development
+
+Build: `npm run build`
+Test: `npm test`
+Dev: `npm run dev` (port 3000)
+Lint: `npm run lint`
+
+Database:
+- Migrate: `npx prisma migrate dev`
+- Studio: `npx prisma studio`
+
+## Critical Rules
+
+- All payments through Stripe API only - never store card data
+- Use server actions for mutations, not API routes
+- Run `npm test` before pushing
+
+## Reference Documentation
+
+When working on specific tasks, read:
+- `agent_docs/testing.md` - Playwright E2E and Jest unit tests
+- `agent_docs/database.md` - Prisma schema and migrations
+- `agent_docs/deployment.md` - Vercel deployment process
+- `agent_docs/stripe.md` - Payment integration patterns
+```
+
+## Companion agent_docs/
+
+### agent_docs/testing.md
+
+```markdown
+# Testing
+
+## Commands
+- All: `npm test`
+- Unit: `npm run test:unit`
+- E2E: `npm run test:e2e`
+- Watch: `npm run test:watch`
+
+## Structure
+tests/
+├── unit/        # Jest unit tests
+├── e2e/         # Playwright E2E
+└── fixtures/    # Test data
+
+## E2E Patterns
+Playwright tests in `tests/e2e/`. Run against dev server:
+```bash
+npm run dev &
+npm run test:e2e
+```
+
+## Fixtures
+User fixtures in `tests/fixtures/users.ts`.
+Product fixtures auto-generated from seed data.
+
+## Coverage
+Minimum 80%. CI fails below threshold.
+```
+
+### agent_docs/database.md
+
+```markdown
+# Database
+
+## Tech
+PostgreSQL 15 via Prisma ORM
+
+## Schema
+Main tables:
+- `User` - Accounts and profiles
+- `Product` - Product catalog
+- `Order` - Purchase orders
+- `OrderItem` - Line items
+
+Schema: `prisma/schema.prisma`
+
+## Commands
+- Generate client: `npx prisma generate`
+- Create migration: `npx prisma migrate dev --name [name]`
+- Apply migrations: `npx prisma migrate deploy`
+- Reset (dev only): `npx prisma migrate reset`
+- Browse data: `npx prisma studio`
+
+## Seeding
+`npm run db:seed` loads test data for development.
+
+## Conventions
+- Use `@db.Uuid` for IDs
+- All tables have `createdAt` and `updatedAt`
+- Soft delete via `deletedAt` where needed
+```
+
+### agent_docs/stripe.md
+
+```markdown
+# Stripe Integration
+
+## Overview
+Stripe handles all payment processing. We never store card details.
+
+## Test Mode
+Dev and staging use test mode. Test cards:
+- Success: 4242 4242 4242 4242
+- Decline: 4000 0000 0000 0002
+
+## Webhooks
+Webhook handler: `src/app/api/webhooks/stripe/route.ts`
+
+Events handled:
+- `checkout.session.completed`
+- `payment_intent.succeeded`
+- `payment_intent.failed`
+
+## Local Testing
+```bash
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+```
+
+## Keys
+- Dev: In `.env.local`
+- Prod: In Vercel environment variables
+
+Never commit Stripe keys. Never log them.
+```
+
+## Why This Works
+
+| Aspect | Implementation |
+|--------|----------------|
+| Line count | 52 lines in CLAUDE.md |
+| Universal | Tech stack and rules apply every session |
+| Progressive | Payment, testing, database details in agent_docs/ |
+| Non-obvious | Stripe-only rule, server actions preference |
+| Current | Commands match actual package.json |
+
+## Adaptation Guide
+
+To adapt for your web project:
+
+1. Replace project name and description
+2. Update tech stack to match yours
+3. Adjust directory structure
+4. Update commands from your package.json
+5. Write 2-3 critical rules specific to your project
+6. Create agent_docs/ for your major subsystems


### PR DESCRIPTION
New skill for creating well-crafted, minimal CLAUDE.md files (~60 lines) following HumanLayer guide best practices and progressive disclosure patterns.

Features:
- The 60-Line Rule for optimal CLAUDE.md sizing
- WHAT/WHY/HOW structure template
- Progressive disclosure via agent_docs/ directory
- Comprehensive anti-patterns guide
- Project-type examples (web app, Python library, monorepo)
- Audit capability for existing CLAUDE.md files
- Agent docs generation workflow

Based on research from HumanLayer and Anthropic Claude Code best practices.