### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AI Skills Collection
 
+[![Run in Smithery](https://smithery.ai/badge/skills/leegonzales)](https://smithery.ai/skills?ns=leegonzales&utm_source=github&utm_medium=badge)
+
+
 A curated collection of professional skills for Claude Code and Claude web chat, designed for enhanced development, analysis, writing, and reasoning workflows.
 
 ## What Are Claude Skills?


### PR DESCRIPTION
## Add skill discoverability badge

Your 15 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/leegonzales)](https://smithery.ai/skills?ns=leegonzales&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.